### PR TITLE
update the link of b3log/pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Gin is a HTTP web framework written in Go (Golang). It features a Martini-like A
 
 * [Massad/gin-boilerplate](https://github.com/Massad/gin-boilerplate) Gin Framework with a structured starter project that defaults to PostgreSQL database and Redis as the session storage.
 * [wangsongyan/wblog](https://github.com/wangsongyan/wblog) Blog based on gin and gorm
-* [b3log/pipe](https://github.com/b3log/pipe) A small and beautiful blogging platform, [demo](http://pipe.b3log.org/)
+* [b3log/pipe](https://github.com/88250/pipe/) A small and beautiful blogging platform, [demo](http://pipe.b3log.org/)
 * [TeaMeow/KitSvc](https://github.com/TeaMeow/KitSvc) Microservice framework based on gin, consul, prometheus, eventStore, gorm and NSQ
 * [gin-gonic/examples](https://github.com/gin-gonic/examples) A repository to host examples and tutorials for Gin. https://gin-gonic.com/docs/
 * [appleboy/gorush](https://github.com/appleboy/gorush) A push notification server written in Go

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Gin is a HTTP web framework written in Go (Golang). It features a Martini-like A
 
 * [Massad/gin-boilerplate](https://github.com/Massad/gin-boilerplate) Gin Framework with a structured starter project that defaults to PostgreSQL database and Redis as the session storage.
 * [wangsongyan/wblog](https://github.com/wangsongyan/wblog) Blog based on gin and gorm
-* [b3log/pipe](https://github.com/88250/pipe/) A small and beautiful blogging platform, [demo](http://pipe.b3log.org/)
+* [b3log/pipe](https://github.com/88250/pipe) A small and beautiful blogging platform, [demo](http://pipe.b3log.org/)
 * [TeaMeow/KitSvc](https://github.com/TeaMeow/KitSvc) Microservice framework based on gin, consul, prometheus, eventStore, gorm and NSQ
 * [gin-gonic/examples](https://github.com/gin-gonic/examples) A repository to host examples and tutorials for Gin. https://gin-gonic.com/docs/
 * [appleboy/gorush](https://github.com/appleboy/gorush) A push notification server written in Go


### PR DESCRIPTION
[b3log/pipe](https://github.com/b3log/pipe)'s link current already 404, change to new link -> [b3log/pipe](https://github.com/88250/pipe)